### PR TITLE
KAFKA-9924: Add RocksDB metric num-entries-active-mem-table

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -437,8 +437,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                 metrics.addMetric(metricName, metricConfig, valueProvider);
                 storeLevelMetrics.computeIfAbsent(key, ignored -> new LinkedList<>()).push(metricName);
             }
-        } else {
-            throw new IllegalStateException("Store level metric " + metricName + " has already been added!");
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBuffer.java
@@ -236,7 +236,7 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
         memBufferSize = 0;
         minTimestamp = Long.MAX_VALUE;
         updateBufferMetrics();
-        streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, storeName);
+        streamsMetrics.removeAllStoreLevelSensorsAndMetrics(threadId, taskId, storeName);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -207,7 +207,7 @@ public class MeteredKeyValueStore<K, V>
         try {
             wrapped().close();
         } finally {
-            streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, name());
+            streamsMetrics.removeAllStoreLevelSensorsAndMetrics(threadId, taskId, name());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -241,7 +241,7 @@ public class MeteredSessionStore<K, V>
         try {
             wrapped().close();
         } finally {
-            streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, name());
+            streamsMetrics.removeAllStoreLevelSensorsAndMetrics(threadId, taskId, name());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -210,7 +210,7 @@ public class MeteredWindowStore<K, V>
         try {
             wrapped().close();
         } finally {
-            streamsMetrics.removeAllStoreLevelSensors(threadId, taskId, name());
+            streamsMetrics.removeAllStoreLevelSensorsAndMetrics(threadId, taskId, name());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetrics.java
@@ -16,10 +16,12 @@
  */
 package org.apache.kafka.streams.state.internals.metrics;
 
+import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 
+import java.math.BigInteger;
 import java.util.Objects;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.AVG_SUFFIX;
@@ -33,7 +35,7 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addSumMetricToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addValueMetricToSensor;
 
-public class RocksDBMetrics {
+public class  RocksDBMetrics {
     private RocksDBMetrics() {}
 
     private static final String BYTES_WRITTEN_TO_DB = "bytes-written";
@@ -56,6 +58,7 @@ public class RocksDBMetrics {
     private static final String COMPACTION_TIME_MAX = COMPACTION_TIME + MAX_SUFFIX;
     private static final String NUMBER_OF_OPEN_FILES = "number-open-files";
     private static final String NUMBER_OF_FILE_ERRORS = "number-file-errors";
+    static final String NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE = "num-entries-active-mem-table";
 
     private static final String BYTES_WRITTEN_TO_DB_RATE_DESCRIPTION =
         "Average number of bytes written per second to the RocksDB state store";
@@ -94,6 +97,8 @@ public class RocksDBMetrics {
     private static final String COMPACTION_TIME_MAX_DESCRIPTION = "Maximum time spent on compaction in ms";
     private static final String NUMBER_OF_OPEN_FILES_DESCRIPTION = "Number of currently open files";
     private static final String NUMBER_OF_FILE_ERRORS_DESCRIPTION = "Total number of file errors occurred";
+    private static final String NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE_DESCRIPTION =
+            "Current total number of entries in the active memtable";
 
     public static class RocksDBMetricContext {
         private final String threadId;
@@ -472,6 +477,21 @@ public class RocksDBMetrics {
             NUMBER_OF_FILE_ERRORS_DESCRIPTION
         );
         return sensor;
+    }
+
+    public static void addNumEntriesActiveMemTableMetric(final StreamsMetricsImpl streamsMetrics,
+                                                         final RocksDBMetricContext metricContext,
+                                                         final Gauge<BigInteger> valueProvider) {
+        streamsMetrics.addStoreLevelMutableMetric(
+            metricContext.threadId(),
+            metricContext.taskName(),
+            metricContext.metricsScope(),
+            metricContext.storeName(),
+            NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE,
+            NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE_DESCRIPTION,
+            RecordingLevel.INFO,
+            valueProvider
+        );
     }
 
     private static Sensor createSensor(final StreamsMetricsImpl streamsMetrics,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorder.java
@@ -18,19 +18,25 @@ package org.apache.kafka.streams.state.internals.metrics;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.RocksDBMetricContext;
 import org.rocksdb.Cache;
 import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
 import org.rocksdb.TickerType;
 import org.slf4j.Logger;
 
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE;
 
 public class RocksDBMetricsRecorder {
 
@@ -56,6 +62,9 @@ public class RocksDBMetricsRecorder {
             }
         }
     }
+
+    private static final String ROCKSDB_PROPERTIES_PREFIX = "rocksdb.";
+    private static final ByteBuffer CONVERSION_BUFFER = ByteBuffer.allocate(Long.BYTES);
 
     private final Logger logger;
 
@@ -112,7 +121,10 @@ public class RocksDBMetricsRecorder {
             throw new IllegalStateException("Metrics recorder is re-initialised with different Streams metrics. "
                 + "This is a bug in Kafka Streams.");
         }
-        initSensors(streamsMetrics, taskId);
+        final RocksDBMetricContext metricContext =
+                new RocksDBMetricContext(threadId, taskId.toString(), metricsScope, storeName);
+        initSensors(streamsMetrics, metricContext);
+        initGauges(streamsMetrics, metricContext);
         this.taskId = taskId;
         this.streamsMetrics = streamsMetrics;
     }
@@ -133,9 +145,7 @@ public class RocksDBMetricsRecorder {
         storeToValueProviders.put(segmentName, new DbAndCacheAndStatistics(db, cache, statistics));
     }
 
-    private void initSensors(final StreamsMetricsImpl streamsMetrics, final TaskId taskId) {
-        final RocksDBMetricContext metricContext =
-            new RocksDBMetricContext(threadId, taskId.toString(), metricsScope, storeName);
+    private void initSensors(final StreamsMetricsImpl streamsMetrics, final RocksDBMetricContext metricContext) {
         bytesWrittenToDatabaseSensor = RocksDBMetrics.bytesWrittenToDatabaseSensor(streamsMetrics, metricContext);
         bytesReadFromDatabaseSensor = RocksDBMetrics.bytesReadFromDatabaseSensor(streamsMetrics, metricContext);
         memtableBytesFlushedSensor = RocksDBMetrics.memtableBytesFlushedSensor(streamsMetrics, metricContext);
@@ -149,6 +159,27 @@ public class RocksDBMetricsRecorder {
         bytesReadDuringCompactionSensor = RocksDBMetrics.bytesReadDuringCompactionSensor(streamsMetrics, metricContext);
         numberOfOpenFilesSensor = RocksDBMetrics.numberOfOpenFilesSensor(streamsMetrics, metricContext);
         numberOfFileErrorsSensor = RocksDBMetrics.numberOfFileErrorsSensor(streamsMetrics, metricContext);
+    }
+
+    private void initGauges(final StreamsMetricsImpl streamsMetrics, final RocksDBMetricContext metricContext) {
+        RocksDBMetrics.addNumEntriesActiveMemTableMetric(streamsMetrics, metricContext, (metricsConfig, now) -> {
+            BigInteger result = BigInteger.valueOf(0);
+            for (final DbAndCacheAndStatistics valueProvider : storeToValueProviders.values()) {
+                try {
+                    result = result.add(new BigInteger(1, longToBytes(
+                            valueProvider.db.getAggregatedLongProperty(ROCKSDB_PROPERTIES_PREFIX + NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE))));
+
+                } catch (final RocksDBException e) {
+                    throw new ProcessorStateException("Error adding RocksDB metric " + NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE, e);
+                }
+            }
+            return result;
+        });
+    }
+
+    private static byte[] longToBytes(final long data) {
+        CONVERSION_BUFFER.putLong(0, data);
+        return CONVERSION_BUFFER.array();
     }
 
     public void removeValueProviders(final String segmentName) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RocksDBMetricsIntegrationTest.java
@@ -100,6 +100,7 @@ public class RocksDBMetricsIntegrationTest {
     private static final String BYTES_WRITTEN_DURING_COMPACTION_RATE = "bytes-written-compaction-rate";
     private static final String NUMBER_OF_OPEN_FILES = "number-open-files";
     private static final String NUMBER_OF_FILE_ERRORS = "number-file-errors-total";
+    private static final String NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE = "num-entries-active-mem-table";
 
     @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
@@ -255,6 +256,7 @@ public class RocksDBMetricsIntegrationTest {
         checkMetricByName(listMetricStore, BYTES_WRITTEN_DURING_COMPACTION_RATE, 1);
         checkMetricByName(listMetricStore, NUMBER_OF_OPEN_FILES, 1);
         checkMetricByName(listMetricStore, NUMBER_OF_FILE_ERRORS, 1);
+        checkMetricByName(listMetricStore, NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE, 1);
     }
 
     private void checkMetricByName(final List<Metric> listMetric,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -30,6 +30,8 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ImmutableMetricValue;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 import org.apache.kafka.test.StreamsTestUtils;
+import org.easymock.Capture;
+import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.easymock.IArgumentMatcher;
 import org.junit.Test;
@@ -54,13 +56,16 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATE_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.STATE_STORE_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxLatencyToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.niceMock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.resetToDefault;
@@ -68,6 +73,7 @@ import static org.easymock.EasyMock.verify;
 import static org.easymock.EasyMock.eq;
 import static org.hamcrest.CoreMatchers.equalToObject;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -78,48 +84,59 @@ import static org.junit.Assert.assertTrue;
 import static org.powermock.api.easymock.PowerMock.createMock;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Sensor.class)
+@PrepareForTest({Sensor.class, KafkaMetric.class})
 public class StreamsMetricsImplTest {
 
     private final static String SENSOR_PREFIX_DELIMITER = ".";
     private final static String SENSOR_NAME_DELIMITER = ".s.";
+    private final static String SENSOR_NAME_1 = "sensor1";
+    private final static String SENSOR_NAME_2 = "sensor2";
     private final static String INTERNAL_PREFIX = "internal";
     private final static String VERSION = StreamsConfig.METRICS_LATEST;
     private final static String CLIENT_ID = "test-client";
-    private final static String THREAD_ID = "test-thread";
-    private final static String TASK_ID = "test-task";
+    private final static String THREAD_ID1 = "test-thread-1";
+    private final static String THREAD_ID2 = "test-thread-2";
+    private final static String TASK_ID1 = "test-task-1";
+    private final static String TASK_ID2 = "test-task-2";
     private final static String METRIC_NAME1 = "test-metric1";
     private final static String METRIC_NAME2 = "test-metric2";
     private final static String THREAD_ID_TAG = "thread-id";
     private final static String THREAD_ID_TAG_0100_TO_24 = "client-id";
     private final static String TASK_ID_TAG = "task-id";
-    private final static String STORE_ID_TAG = "state-id";
-    private final static String RECORD_CACHE_ID_TAG = "record-cache-id";
     private final static String SCOPE_NAME = "test-scope";
+    private final static String STORE_ID_TAG = "-state-id";
+    private final static String STORE_NAME1 = "store1";
+    private final static String STORE_NAME2 = "store2";
+    private final static Map<String, String> STORE_LEVEL_TAG_MAP = mkMap(
+        mkEntry(THREAD_ID_TAG, THREAD_ID1),
+        mkEntry(TASK_ID_TAG, TASK_ID1),
+        mkEntry(SCOPE_NAME + STORE_ID_TAG, STORE_NAME1)
+    );
+    private final static String RECORD_CACHE_ID_TAG = "record-cache-id";
     private final static String ENTITY_NAME = "test-entity";
     private final static String OPERATION_NAME = "test-operation";
     private final static String CUSTOM_TAG_KEY1 = "test-key1";
     private final static String CUSTOM_TAG_VALUE1 = "test-value1";
     private final static String CUSTOM_TAG_KEY2 = "test-key2";
     private final static String CUSTOM_TAG_VALUE2 = "test-value2";
+    private final static RecordingLevel INFO_RECORDING_LEVEL = RecordingLevel.INFO;
+    private final static String DESCRIPTION1 = "description number one";
+    private final static String DESCRIPTION2 = "description number two";
+    private final static String DESCRIPTION3 = "description number three";
+    private final static Gauge<String> VALUE_PROVIDER = (config, now) -> "mutable-value";
+
+
 
     private final Metrics metrics = new Metrics();
     private final Sensor sensor = metrics.sensor("dummy");
-    private final String storeName = "store";
-    private final String sensorName1 = "sensor1";
-    private final String sensorName2 = "sensor2";
     private final String metricNamePrefix = "metric";
     private final String group = "group";
     private final Map<String, String> tags = mkMap(mkEntry("tag", "value"));
-    private final String description1 = "description number one";
-    private final String description2 = "description number two";
-    private final String description3 = "description number three";
-    private final String description4 = "description number four";
-    private final Map<String, String> clientLevelTags = mkMap(mkEntry("client-id", CLIENT_ID));
+    private final Map<String, String> clientLevelTags = mkMap(mkEntry(CLIENT_ID_TAG, CLIENT_ID));
     private final MetricName metricName1 =
-        new MetricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags);
+        new MetricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, DESCRIPTION1, clientLevelTags);
     private final MetricName metricName2 =
-        new MetricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description2, clientLevelTags);
+        new MetricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, DESCRIPTION2, clientLevelTags);
     private final MockTime time = new MockTime(0);
     private final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
@@ -176,57 +193,81 @@ public class StreamsMetricsImplTest {
         return null;
     }
 
-    private void addSensorsOnAllLevels(final Metrics metrics, final StreamsMetricsImpl streamsMetrics) {
-        expect(metrics.sensor(anyString(), anyObject(RecordingLevel.class), anyObject(Sensor[].class)))
+    private Capture<String> addSensorsOnAllLevels(final Metrics metrics, final StreamsMetricsImpl streamsMetrics) {
+        final Capture<String> sensorKeys = newCapture(CaptureType.ALL);
+        final Sensor[] parents = {};
+        expect(metrics.sensor(capture(sensorKeys), eq(INFO_RECORDING_LEVEL), parents))
             .andStubReturn(sensor);
-        expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags))
+        expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, DESCRIPTION1, clientLevelTags))
             .andReturn(metricName1);
-        expect(metrics.metricName(METRIC_NAME2, CLIENT_LEVEL_GROUP, description2, clientLevelTags))
+        expect(metrics.metricName(METRIC_NAME2, CLIENT_LEVEL_GROUP, DESCRIPTION2, clientLevelTags))
             .andReturn(metricName2);
         replay(metrics);
-        streamsMetrics.addClientLevelImmutableMetric(METRIC_NAME1, description1, RecordingLevel.INFO, "value");
-        streamsMetrics.addClientLevelImmutableMetric(METRIC_NAME2, description2, RecordingLevel.INFO, "value");
-        streamsMetrics.threadLevelSensor(THREAD_ID, sensorName1, RecordingLevel.INFO);
-        streamsMetrics.threadLevelSensor(THREAD_ID, sensorName2, RecordingLevel.INFO);
-        streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, sensorName1, RecordingLevel.INFO);
-        streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, sensorName2, RecordingLevel.INFO);
-        streamsMetrics.storeLevelSensor(THREAD_ID, TASK_ID, storeName, sensorName1, RecordingLevel.INFO);
-        streamsMetrics.storeLevelSensor(THREAD_ID, TASK_ID, storeName, sensorName2, RecordingLevel.INFO);
+        streamsMetrics.addClientLevelImmutableMetric(METRIC_NAME1, DESCRIPTION1, INFO_RECORDING_LEVEL, "value");
+        streamsMetrics.addClientLevelImmutableMetric(METRIC_NAME2, DESCRIPTION2, INFO_RECORDING_LEVEL, "value");
+        streamsMetrics.threadLevelSensor(THREAD_ID1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+        streamsMetrics.threadLevelSensor(THREAD_ID1, SENSOR_NAME_2, INFO_RECORDING_LEVEL);
+        streamsMetrics.taskLevelSensor(THREAD_ID1, TASK_ID1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+        streamsMetrics.taskLevelSensor(THREAD_ID1, TASK_ID1, SENSOR_NAME_2, INFO_RECORDING_LEVEL);
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_2, INFO_RECORDING_LEVEL);
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME2, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+        streamsMetrics.addStoreLevelMutableMetric(
+            THREAD_ID1,
+            TASK_ID1,
+            SCOPE_NAME,
+            STORE_NAME1,
+            METRIC_NAME1,
+            DESCRIPTION1,
+            INFO_RECORDING_LEVEL,
+            VALUE_PROVIDER
+        );
+        streamsMetrics.addStoreLevelMutableMetric(
+            THREAD_ID1,
+            TASK_ID1,
+            SCOPE_NAME,
+            STORE_NAME1,
+            METRIC_NAME2,
+            DESCRIPTION2,
+            INFO_RECORDING_LEVEL,
+            VALUE_PROVIDER
+        );
+        streamsMetrics.addStoreLevelMutableMetric(
+            THREAD_ID1,
+            TASK_ID1,
+            SCOPE_NAME,
+            STORE_NAME2,
+            METRIC_NAME1,
+            DESCRIPTION1,
+            INFO_RECORDING_LEVEL,
+            VALUE_PROVIDER
+        );
+        return sensorKeys;
     }
 
-    private void setupGetNewSensorTest(final Metrics metrics,
-                                       final String level,
+    private Capture<String> setupGetNewSensorTest(final Metrics metrics,
                                        final RecordingLevel recordingLevel) {
-        final String fullSensorName = fullSensorName(level);
-        expect(metrics.getSensor(fullSensorName)).andStubReturn(null);
+        final Capture<String> sensorKey = newCapture(CaptureType.ALL);
+        expect(metrics.getSensor(capture(sensorKey))).andStubReturn(null);
         final Sensor[] parents = {};
-        expect(metrics.sensor(fullSensorName, recordingLevel, parents)).andReturn(sensor);
+        expect(metrics.sensor(capture(sensorKey), eq(recordingLevel), parents)).andReturn(sensor);
         replay(metrics);
+        return sensorKey;
     }
 
-    private void setupGetExistingSensorTest(final Metrics metrics,
-                                            final String level) {
-        final String fullSensorName = fullSensorName(level);
-        expect(metrics.getSensor(fullSensorName)).andStubReturn(sensor);
+    private void setupGetExistingSensorTest(final Metrics metrics) {
+        expect(metrics.getSensor(anyString())).andStubReturn(sensor);
         replay(metrics);
-    }
-
-    private String fullSensorName(final String level) {
-        return INTERNAL_PREFIX + SENSOR_PREFIX_DELIMITER + level + SENSOR_NAME_DELIMITER + sensorName1;
     }
 
     @Test
     public void shouldGetNewThreadLevelSensor() {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
-        setupGetNewSensorTest(metrics, THREAD_ID, recordingLevel);
+        setupGetNewSensorTest(metrics, recordingLevel);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
-        final Sensor actualSensor = streamsMetrics.threadLevelSensor(
-            THREAD_ID,
-            sensorName1,
-            recordingLevel
-        );
+        final Sensor actualSensor = streamsMetrics.threadLevelSensor(THREAD_ID1, SENSOR_NAME_1, recordingLevel);
 
         verify(metrics);
         assertThat(actualSensor, is(equalToObject(sensor)));
@@ -236,14 +277,10 @@ public class StreamsMetricsImplTest {
     public void shouldGetExistingThreadLevelSensor() {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
-        setupGetExistingSensorTest(metrics, THREAD_ID);
+        setupGetExistingSensorTest(metrics);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
-        final Sensor actualSensor = streamsMetrics.threadLevelSensor(
-            THREAD_ID,
-            sensorName1,
-            recordingLevel
-        );
+        final Sensor actualSensor = streamsMetrics.threadLevelSensor(THREAD_ID1, SENSOR_NAME_1, recordingLevel);
 
         verify(metrics);
         assertThat(actualSensor, is(equalToObject(sensor)));
@@ -253,13 +290,13 @@ public class StreamsMetricsImplTest {
     public void shouldGetNewTaskLevelSensor() {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
-        setupGetNewSensorTest(metrics, THREAD_ID + ".task." + TASK_ID, recordingLevel);
+        setupGetNewSensorTest(metrics, recordingLevel);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
         final Sensor actualSensor = streamsMetrics.taskLevelSensor(
-            THREAD_ID,
-            TASK_ID,
-            sensorName1,
+            THREAD_ID1,
+            TASK_ID1,
+            SENSOR_NAME_1,
             recordingLevel
         );
 
@@ -271,13 +308,13 @@ public class StreamsMetricsImplTest {
     public void shouldGetExistingTaskLevelSensor() {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
-        setupGetExistingSensorTest(metrics, THREAD_ID + ".task." + TASK_ID);
+        setupGetExistingSensorTest(metrics);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
         final Sensor actualSensor = streamsMetrics.taskLevelSensor(
-            THREAD_ID,
-            TASK_ID,
-            sensorName1,
+            THREAD_ID1,
+            TASK_ID1,
+            SENSOR_NAME_1,
             recordingLevel
         );
 
@@ -286,49 +323,190 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
-    public void shouldGetNewStoreLevelSensor() {
+    public void shouldGetNewStoreLevelSensorIfNoneExists() {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
-        setupGetNewSensorTest(
-            metrics,
-            THREAD_ID + ".task." + storeName + SENSOR_PREFIX_DELIMITER + storeName + SENSOR_PREFIX_DELIMITER
-                + TASK_ID,
-            recordingLevel
-        );
+        final Capture<String> sensorKeys = setupGetNewSensorTest(metrics, recordingLevel);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
         final Sensor actualSensor = streamsMetrics.storeLevelSensor(
-            THREAD_ID,
-            storeName,
-            TASK_ID,
-            sensorName1,
+            THREAD_ID1,
+            TASK_ID1,
+            STORE_NAME1,
+            SENSOR_NAME_1,
             recordingLevel
         );
 
         verify(metrics);
         assertThat(actualSensor, is(equalToObject(sensor)));
+        assertThat(sensorKeys.getValues().get(0), is(sensorKeys.getValues().get(1)));
     }
 
     @Test
     public void shouldGetExistingStoreLevelSensor() {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
-        setupGetExistingSensorTest(
-            metrics, THREAD_ID + ".task." + storeName + SENSOR_PREFIX_DELIMITER + storeName + SENSOR_PREFIX_DELIMITER
-                + TASK_ID
-        );
+        setupGetExistingSensorTest(metrics);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
         final Sensor actualSensor = streamsMetrics.storeLevelSensor(
-            THREAD_ID,
-            storeName,
-            TASK_ID,
-            sensorName1,
+            THREAD_ID1,
+            TASK_ID1,
+            STORE_NAME1,
+            SENSOR_NAME_1,
             recordingLevel
         );
 
         verify(metrics);
         assertThat(actualSensor, is(equalToObject(sensor)));
+    }
+
+    @Test
+    public void shouldUseSameStoreLevelSensorKeyWithTwoDifferentSensorNames() {
+        final Metrics metrics = niceMock(Metrics.class);
+        final Capture<String> sensorKeys = setUpSensorKeyTests(metrics);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
+
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_2, INFO_RECORDING_LEVEL);
+
+        assertThat(sensorKeys.getValues().get(0), not(sensorKeys.getValues().get(1)));
+    }
+
+    @Test
+    public void shouldNotUseSameStoreLevelSensorKeyWithDifferentTaskIds() {
+        final Metrics metrics = niceMock(Metrics.class);
+        final Capture<String> sensorKeys = setUpSensorKeyTests(metrics);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
+
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID2, STORE_NAME1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+
+        assertThat(sensorKeys.getValues().get(0), not(sensorKeys.getValues().get(1)));
+    }
+
+    @Test
+    public void shouldNotUseSameStoreLevelSensorKeyWithDifferentStoreNames() {
+        final Metrics metrics = niceMock(Metrics.class);
+        final Capture<String> sensorKeys = setUpSensorKeyTests(metrics);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
+
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME2, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+
+        assertThat(sensorKeys.getValues().get(0), not(sensorKeys.getValues().get(1)));
+    }
+
+    @Test
+    public void shouldNotUseSameStoreLevelSensorKeyWithDifferentThreadIds() {
+        final Metrics metrics = niceMock(Metrics.class);
+        final Capture<String> sensorKeys = setUpSensorKeyTests(metrics);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
+
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+        streamsMetrics.storeLevelSensor(THREAD_ID2, TASK_ID1, STORE_NAME1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+
+        assertThat(sensorKeys.getValues().get(0), not(sensorKeys.getValues().get(1)));
+    }
+
+    @Test
+    public void shouldUseSameStoreLevelSensorKeyWithSameSensorNames() {
+        final Metrics metrics = niceMock(Metrics.class);
+        final Capture<String> sensorKeys = setUpSensorKeyTests(metrics);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
+
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+        streamsMetrics.storeLevelSensor(THREAD_ID1, TASK_ID1, STORE_NAME1, SENSOR_NAME_1, INFO_RECORDING_LEVEL);
+
+        assertThat(sensorKeys.getValues().get(0), is(sensorKeys.getValues().get(1)));
+    }
+
+    private Capture<String> setUpSensorKeyTests(final Metrics metrics) {
+        final Capture<String> sensorKeys = newCapture(CaptureType.ALL);
+        expect(metrics.getSensor(capture(sensorKeys))).andStubReturn(sensor);
+        replay(metrics);
+        return sensorKeys;
+    }
+
+    @Test
+    public void shouldAddStoreLevelMutableMetric() {
+        final Metrics metrics = mock(Metrics.class);
+        final MetricName metricName =
+            new MetricName(METRIC_NAME1, STATE_STORE_LEVEL_GROUP, DESCRIPTION1, STORE_LEVEL_TAG_MAP);
+        final MetricConfig metricConfig = new MetricConfig().recordLevel(INFO_RECORDING_LEVEL);
+        expect(metrics.metricName(METRIC_NAME1, STATE_STORE_LEVEL_GROUP, DESCRIPTION1, STORE_LEVEL_TAG_MAP))
+            .andReturn(metricName);
+        expect(metrics.metric(metricName)).andReturn(null);
+        metrics.addMetric(eq(metricName), eqMetricConfig(metricConfig), eq(VALUE_PROVIDER));
+        replay(metrics);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
+
+        streamsMetrics.addStoreLevelMutableMetric(
+            THREAD_ID1,
+            TASK_ID1,
+            SCOPE_NAME,
+            STORE_NAME1,
+            METRIC_NAME1,
+            DESCRIPTION1,
+            INFO_RECORDING_LEVEL,
+            VALUE_PROVIDER
+        );
+
+        verify(metrics);
+    }
+
+    @Test
+    public void shouldThrowWhenStoreLevelMutableMetricAlreadyExists() {
+        final Metrics metrics = mock(Metrics.class);
+        final MetricName metricName =
+            new MetricName(METRIC_NAME1, STATE_STORE_LEVEL_GROUP, DESCRIPTION1, STORE_LEVEL_TAG_MAP);
+        expect(metrics.metricName(METRIC_NAME1, STATE_STORE_LEVEL_GROUP, DESCRIPTION1, STORE_LEVEL_TAG_MAP))
+            .andReturn(metricName);
+        expect(metrics.metric(metricName)).andReturn(mock(KafkaMetric.class));
+        replay(metrics);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
+
+        assertThrows(
+            "Store level metric " + metricName + " has already been added!",
+            IllegalStateException.class,
+            () -> streamsMetrics.addStoreLevelMutableMetric(
+                THREAD_ID1,
+                TASK_ID1,
+                SCOPE_NAME,
+                STORE_NAME1,
+                METRIC_NAME1,
+                DESCRIPTION1,
+                INFO_RECORDING_LEVEL,
+                VALUE_PROVIDER
+            )
+        );
+
+        verify(metrics);
+    }
+
+    @Test
+    public void shouldRemoveStateStoreLevelSensors() {
+        final Metrics metrics = niceMock(Metrics.class);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
+        final MetricName metricName1 =
+            new MetricName(METRIC_NAME1, STATE_STORE_LEVEL_GROUP, DESCRIPTION1, STORE_LEVEL_TAG_MAP);
+        final MetricName metricName2 =
+            new MetricName(METRIC_NAME2, STATE_STORE_LEVEL_GROUP, DESCRIPTION2, STORE_LEVEL_TAG_MAP);
+        expect(metrics.metricName(METRIC_NAME1, STATE_STORE_LEVEL_GROUP, DESCRIPTION1, STORE_LEVEL_TAG_MAP))
+            .andReturn(metricName1);
+        expect(metrics.metricName(METRIC_NAME2, STATE_STORE_LEVEL_GROUP, DESCRIPTION2, STORE_LEVEL_TAG_MAP))
+            .andReturn(metricName2);
+        final Capture<String> sensorKeys = addSensorsOnAllLevels(metrics, streamsMetrics);
+        resetToDefault(metrics);
+        metrics.removeSensor(sensorKeys.getValues().get(4));
+        metrics.removeSensor(sensorKeys.getValues().get(5));
+        expect(metrics.removeMetric(metricName1)).andReturn(mock(KafkaMetric.class));
+        expect(metrics.removeMetric(metricName2)).andReturn(mock(KafkaMetric.class));
+        replay(metrics);
+
+        streamsMetrics.removeAllStoreLevelSensorsAndMetrics(THREAD_ID1, TASK_ID1, STORE_NAME1);
+
+        verify(metrics);
     }
 
     @Test
@@ -336,17 +514,14 @@ public class StreamsMetricsImplTest {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
         final String processorNodeName = "processorNodeName";
-        setupGetNewSensorTest(metrics, THREAD_ID + ".task." + TASK_ID + SENSOR_PREFIX_DELIMITER + "node"
-            + SENSOR_PREFIX_DELIMITER + processorNodeName,
-            recordingLevel
-        );
+        setupGetNewSensorTest(metrics, recordingLevel);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
         final Sensor actualSensor = streamsMetrics.nodeLevelSensor(
-            THREAD_ID,
-            TASK_ID,
+            THREAD_ID1,
+            TASK_ID1,
             processorNodeName,
-            sensorName1,
+            SENSOR_NAME_1,
             recordingLevel
         );
 
@@ -359,17 +534,14 @@ public class StreamsMetricsImplTest {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
         final String processorNodeName = "processorNodeName";
-        setupGetExistingSensorTest(
-            metrics, THREAD_ID + ".task." + TASK_ID + SENSOR_PREFIX_DELIMITER
-            + "node" + SENSOR_PREFIX_DELIMITER + processorNodeName
-        );
+        setupGetExistingSensorTest(metrics);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
         final Sensor actualSensor = streamsMetrics.nodeLevelSensor(
-            THREAD_ID,
-            TASK_ID,
+            THREAD_ID1,
+            TASK_ID1,
             processorNodeName,
-            sensorName1,
+            SENSOR_NAME_1,
             recordingLevel
         );
 
@@ -382,18 +554,14 @@ public class StreamsMetricsImplTest {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
         final String processorCacheName = "processorNodeName";
-        setupGetNewSensorTest(
-            metrics, THREAD_ID + ".task." + TASK_ID + SENSOR_PREFIX_DELIMITER
-            + "cache" + SENSOR_PREFIX_DELIMITER + processorCacheName,
-            recordingLevel
-        );
+        setupGetNewSensorTest(metrics, recordingLevel);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
         final Sensor actualSensor = streamsMetrics.cacheLevelSensor(
-            THREAD_ID,
-            TASK_ID,
+            THREAD_ID1,
+            TASK_ID1,
             processorCacheName,
-            sensorName1,
+            SENSOR_NAME_1,
             recordingLevel
         );
 
@@ -406,16 +574,13 @@ public class StreamsMetricsImplTest {
         final Metrics metrics = mock(Metrics.class);
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
         final String processorCacheName = "processorNodeName";
-        setupGetExistingSensorTest(
-            metrics, THREAD_ID + ".task." + TASK_ID + SENSOR_PREFIX_DELIMITER
-            + "cache" + SENSOR_PREFIX_DELIMITER + processorCacheName
-        );
+        setupGetExistingSensorTest(metrics);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
         final Sensor actualSensor = streamsMetrics.cacheLevelSensor(
-            THREAD_ID, TASK_ID,
+            THREAD_ID1, TASK_ID1,
             processorCacheName,
-            sensorName1,
+            SENSOR_NAME_1,
             recordingLevel
         );
 
@@ -430,13 +595,13 @@ public class StreamsMetricsImplTest {
         final MetricConfig metricConfig = new MetricConfig().recordLevel(recordingLevel);
         final String value = "immutable-value";
         final ImmutableMetricValue immutableValue = new ImmutableMetricValue<>(value);
-        expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags))
+        expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, DESCRIPTION1, clientLevelTags))
             .andReturn(metricName1);
         metrics.addMetric(eq(metricName1), eqMetricConfig(metricConfig), eq(immutableValue));
         replay(metrics);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
-        streamsMetrics.addClientLevelImmutableMetric(METRIC_NAME1, description1, recordingLevel, value);
+        streamsMetrics.addClientLevelImmutableMetric(METRIC_NAME1, DESCRIPTION1, recordingLevel, value);
 
         verify(metrics);
     }
@@ -447,13 +612,13 @@ public class StreamsMetricsImplTest {
         final RecordingLevel recordingLevel = RecordingLevel.INFO;
         final MetricConfig metricConfig = new MetricConfig().recordLevel(recordingLevel);
         final Gauge<String> valueProvider = (config, now) -> "mutable-value";
-        expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, description1, clientLevelTags))
+        expect(metrics.metricName(METRIC_NAME1, CLIENT_LEVEL_GROUP, DESCRIPTION1, clientLevelTags))
             .andReturn(metricName1);
         metrics.addMetric(EasyMock.eq(metricName1), eqMetricConfig(metricConfig), eq(valueProvider));
         replay(metrics);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
-        streamsMetrics.addClientLevelMutableMetric(METRIC_NAME1, description1, recordingLevel, valueProvider);
+        streamsMetrics.addClientLevelMutableMetric(METRIC_NAME1, DESCRIPTION1, recordingLevel, valueProvider);
 
         verify(metrics);
     }
@@ -469,8 +634,8 @@ public class StreamsMetricsImplTest {
                                         final RecordingLevel recordingLevel) {
         final String fullSensorNamePrefix = INTERNAL_PREFIX + SENSOR_PREFIX_DELIMITER + level + SENSOR_NAME_DELIMITER;
         resetToDefault(metrics);
-        metrics.removeSensor(fullSensorNamePrefix + sensorName1);
-        metrics.removeSensor(fullSensorNamePrefix + sensorName2);
+        metrics.removeSensor(fullSensorNamePrefix + SENSOR_NAME_1);
+        metrics.removeSensor(fullSensorNamePrefix + SENSOR_NAME_2);
         replay(metrics);
     }
 
@@ -494,9 +659,9 @@ public class StreamsMetricsImplTest {
         final Metrics metrics = niceMock(Metrics.class);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
         addSensorsOnAllLevels(metrics, streamsMetrics);
-        setupRemoveSensorsTest(metrics, THREAD_ID, RecordingLevel.INFO);
+        setupRemoveSensorsTest(metrics, THREAD_ID1, RecordingLevel.INFO);
 
-        streamsMetrics.removeAllThreadLevelSensors(THREAD_ID);
+        streamsMetrics.removeAllThreadLevelSensors(THREAD_ID1);
 
         verify(metrics);
     }
@@ -536,7 +701,7 @@ public class StreamsMetricsImplTest {
     @Test
     public void testMultiLevelSensorRemoval() {
         final Metrics registry = new Metrics();
-        final StreamsMetricsImpl metrics = new StreamsMetricsImpl(registry, THREAD_ID, VERSION, time);
+        final StreamsMetricsImpl metrics = new StreamsMetricsImpl(registry, THREAD_ID1, VERSION, time);
         for (final MetricName defaultMetric : registry.metrics().keySet()) {
             registry.removeMetric(defaultMetric);
         }
@@ -548,39 +713,39 @@ public class StreamsMetricsImplTest {
         final String processorNodeName = "processorNodeName";
         final Map<String, String> nodeTags = mkMap(mkEntry("nkey", "value"));
 
-        final Sensor parent1 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, RecordingLevel.DEBUG);
+        final Sensor parent1 = metrics.taskLevelSensor(THREAD_ID1, taskName, operation, RecordingLevel.DEBUG);
         addAvgAndMaxLatencyToSensor(parent1, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
         addInvocationRateAndCountToSensor(parent1, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation, "", "");
 
         final int numberOfTaskMetrics = registry.metrics().size();
 
-        final Sensor sensor1 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, RecordingLevel.DEBUG, parent1);
+        final Sensor sensor1 = metrics.nodeLevelSensor(THREAD_ID1, taskName, processorNodeName, operation, RecordingLevel.DEBUG, parent1);
         addAvgAndMaxLatencyToSensor(sensor1, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation);
         addInvocationRateAndCountToSensor(sensor1, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation, "", "");
 
         assertThat(registry.metrics().size(), greaterThan(numberOfTaskMetrics));
 
-        metrics.removeAllNodeLevelSensors(THREAD_ID, taskName, processorNodeName);
+        metrics.removeAllNodeLevelSensors(THREAD_ID1, taskName, processorNodeName);
 
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
-        final Sensor parent2 = metrics.taskLevelSensor(THREAD_ID, taskName, operation, RecordingLevel.DEBUG);
+        final Sensor parent2 = metrics.taskLevelSensor(THREAD_ID1, taskName, operation, RecordingLevel.DEBUG);
         addAvgAndMaxLatencyToSensor(parent2, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation);
         addInvocationRateAndCountToSensor(parent2, PROCESSOR_NODE_LEVEL_GROUP, taskTags, operation, "", "");
 
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
-        final Sensor sensor2 = metrics.nodeLevelSensor(THREAD_ID, taskName, processorNodeName, operation, RecordingLevel.DEBUG, parent2);
+        final Sensor sensor2 = metrics.nodeLevelSensor(THREAD_ID1, taskName, processorNodeName, operation, RecordingLevel.DEBUG, parent2);
         addAvgAndMaxLatencyToSensor(sensor2, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation);
         addInvocationRateAndCountToSensor(sensor2, PROCESSOR_NODE_LEVEL_GROUP, nodeTags, operation, "", "");
 
         assertThat(registry.metrics().size(), greaterThan(numberOfTaskMetrics));
 
-        metrics.removeAllNodeLevelSensors(THREAD_ID, taskName, processorNodeName);
+        metrics.removeAllNodeLevelSensors(THREAD_ID1, taskName, processorNodeName);
 
         assertThat(registry.metrics().size(), equalTo(numberOfTaskMetrics));
 
-        metrics.removeAllTaskLevelSensors(THREAD_ID, taskName);
+        metrics.removeAllTaskLevelSensors(THREAD_ID1, taskName);
 
         assertThat(registry.metrics().size(), equalTo(0));
     }
@@ -840,15 +1005,15 @@ public class StreamsMetricsImplTest {
         final String taskName = "test-task";
         final String storeType = "remote-window";
         final String storeName = "window-keeper";
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_ID, builtInMetricsVersion, time);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_ID1, builtInMetricsVersion, time);
 
-        final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(THREAD_ID, taskName, storeType, storeName);
+        final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(THREAD_ID1, taskName, storeType, storeName);
 
         assertThat(tagMap.size(), equalTo(3));
         final boolean isMetricsLatest = builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST);
         assertThat(
             tagMap.get(isMetricsLatest ? StreamsMetricsImpl.THREAD_ID_TAG : StreamsMetricsImpl.THREAD_ID_TAG_0100_TO_24),
-            equalTo(THREAD_ID));
+            equalTo(THREAD_ID1));
         assertThat(tagMap.get(StreamsMetricsImpl.TASK_ID_TAG), equalTo(taskName));
         assertThat(tagMap.get(storeType + "-" + StreamsMetricsImpl.STORE_ID_TAG), equalTo(storeName));
     }
@@ -865,17 +1030,17 @@ public class StreamsMetricsImplTest {
 
     private void shouldGetCacheLevelTagMap(final String builtInMetricsVersion) {
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, THREAD_ID, builtInMetricsVersion, time);
+            new StreamsMetricsImpl(metrics, THREAD_ID1, builtInMetricsVersion, time);
         final String taskName = "taskName";
         final String storeName = "storeName";
 
-        final Map<String, String> tagMap = streamsMetrics.cacheLevelTagMap(THREAD_ID, taskName, storeName);
+        final Map<String, String> tagMap = streamsMetrics.cacheLevelTagMap(THREAD_ID1, taskName, storeName);
 
         assertThat(tagMap.size(), equalTo(3));
         final boolean isMetricsLatest = builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST);
         assertThat(
             tagMap.get(isMetricsLatest ? StreamsMetricsImpl.THREAD_ID_TAG : StreamsMetricsImpl.THREAD_ID_TAG_0100_TO_24),
-            equalTo(THREAD_ID)
+            equalTo(THREAD_ID1)
         );
         assertThat(tagMap.get(TASK_ID_TAG), equalTo(taskName));
         assertThat(tagMap.get(RECORD_CACHE_ID_TAG), equalTo(storeName));
@@ -892,26 +1057,26 @@ public class StreamsMetricsImplTest {
     }
 
     private void shouldGetThreadLevelTagMap(final String builtInMetricsVersion) {
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_ID, builtInMetricsVersion, time);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_ID1, builtInMetricsVersion, time);
 
-        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(THREAD_ID);
+        final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(THREAD_ID1);
 
         assertThat(tagMap.size(), equalTo(1));
         assertThat(
             tagMap.get(builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST) ? THREAD_ID_TAG
                 : THREAD_ID_TAG_0100_TO_24),
-            equalTo(THREAD_ID)
+            equalTo(THREAD_ID1)
         );
     }
 
     @Test
     public void shouldAddInvocationRateToSensor() {
         final Sensor sensor = createMock(Sensor.class);
-        final MetricName expectedMetricName = new MetricName(METRIC_NAME1 + "-rate", group, description1, tags);
+        final MetricName expectedMetricName = new MetricName(METRIC_NAME1 + "-rate", group, DESCRIPTION1, tags);
         expect(sensor.add(eq(expectedMetricName), anyObject(Rate.class))).andReturn(true);
         replay(sensor);
 
-        StreamsMetricsImpl.addInvocationRateToSensor(sensor, group, tags, METRIC_NAME1, description1);
+        StreamsMetricsImpl.addInvocationRateToSensor(sensor, group, tags, METRIC_NAME1, DESCRIPTION1);
 
         verify(sensor);
     }
@@ -919,46 +1084,46 @@ public class StreamsMetricsImplTest {
     @Test
     public void shouldAddAmountRateAndSum() {
         StreamsMetricsImpl
-            .addRateOfSumAndSumMetricsToSensor(sensor, group, tags, metricNamePrefix, description1, description2);
+            .addRateOfSumAndSumMetricsToSensor(sensor, group, tags, metricNamePrefix, DESCRIPTION1, DESCRIPTION2);
 
         final double valueToRecord1 = 18.0;
         final double valueToRecord2 = 72.0;
         final long defaultWindowSizeInSeconds = Duration.ofMillis(new MetricConfig().timeWindowMs()).getSeconds();
         final double expectedRateMetricValue = (valueToRecord1 + valueToRecord2) / defaultWindowSizeInSeconds;
-        verifyMetric(metricNamePrefix + "-rate", description1, valueToRecord1, valueToRecord2, expectedRateMetricValue);
+        verifyMetric(metricNamePrefix + "-rate", DESCRIPTION1, valueToRecord1, valueToRecord2, expectedRateMetricValue);
         final double expectedSumMetricValue = 2 * valueToRecord1 + 2 * valueToRecord2; // values are recorded once for each metric verification
-        verifyMetric(metricNamePrefix + "-total", description2, valueToRecord1, valueToRecord2, expectedSumMetricValue);
+        verifyMetric(metricNamePrefix + "-total", DESCRIPTION2, valueToRecord1, valueToRecord2, expectedSumMetricValue);
         assertThat(metrics.metrics().size(), equalTo(2 + 1)); // one metric is added automatically in the constructor of Metrics
     }
 
     @Test
     public void shouldAddSum() {
-        StreamsMetricsImpl.addSumMetricToSensor(sensor, group, tags, metricNamePrefix, description1);
+        StreamsMetricsImpl.addSumMetricToSensor(sensor, group, tags, metricNamePrefix, DESCRIPTION1);
 
         final double valueToRecord1 = 18.0;
         final double valueToRecord2 = 42.0;
         final double expectedSumMetricValue = valueToRecord1 + valueToRecord2;
-        verifyMetric(metricNamePrefix + "-total", description1, valueToRecord1, valueToRecord2, expectedSumMetricValue);
+        verifyMetric(metricNamePrefix + "-total", DESCRIPTION1, valueToRecord1, valueToRecord2, expectedSumMetricValue);
         assertThat(metrics.metrics().size(), equalTo(1 + 1)); // one metric is added automatically in the constructor of Metrics
     }
 
     @Test
     public void shouldAddAmountRate() {
-        StreamsMetricsImpl.addRateOfSumMetricToSensor(sensor, group, tags, metricNamePrefix, description1);
+        StreamsMetricsImpl.addRateOfSumMetricToSensor(sensor, group, tags, metricNamePrefix, DESCRIPTION1);
 
         final double valueToRecord1 = 18.0;
         final double valueToRecord2 = 72.0;
         final long defaultWindowSizeInSeconds = Duration.ofMillis(new MetricConfig().timeWindowMs()).getSeconds();
         final double expectedRateMetricValue = (valueToRecord1 + valueToRecord2) / defaultWindowSizeInSeconds;
-        verifyMetric(metricNamePrefix + "-rate", description1, valueToRecord1, valueToRecord2, expectedRateMetricValue);
+        verifyMetric(metricNamePrefix + "-rate", DESCRIPTION1, valueToRecord1, valueToRecord2, expectedRateMetricValue);
         assertThat(metrics.metrics().size(), equalTo(1 + 1)); // one metric is added automatically in the constructor of Metrics
     }
 
     @Test
     public void shouldAddValue() {
-        StreamsMetricsImpl.addValueMetricToSensor(sensor, group, tags, metricNamePrefix, description1);
+        StreamsMetricsImpl.addValueMetricToSensor(sensor, group, tags, metricNamePrefix, DESCRIPTION1);
 
-        final KafkaMetric ratioMetric = metrics.metric(new MetricName(metricNamePrefix, group, description1, tags));
+        final KafkaMetric ratioMetric = metrics.metric(new MetricName(metricNamePrefix, group, DESCRIPTION1, tags));
         assertThat(ratioMetric, is(notNullValue()));
         final MetricConfig metricConfig = new MetricConfig();
         final double value1 = 42.0;
@@ -973,47 +1138,47 @@ public class StreamsMetricsImplTest {
     @Test
     public void shouldAddAvgAndTotalMetricsToSensor() {
         StreamsMetricsImpl
-            .addAvgAndSumMetricsToSensor(sensor, group, tags, metricNamePrefix, description1, description2);
+            .addAvgAndSumMetricsToSensor(sensor, group, tags, metricNamePrefix, DESCRIPTION1, DESCRIPTION2);
 
         final double valueToRecord1 = 18.0;
         final double valueToRecord2 = 42.0;
         final double expectedAvgMetricValue = (valueToRecord1 + valueToRecord2) / 2;
-        verifyMetric(metricNamePrefix + "-avg", description1, valueToRecord1, valueToRecord2, expectedAvgMetricValue);
+        verifyMetric(metricNamePrefix + "-avg", DESCRIPTION1, valueToRecord1, valueToRecord2, expectedAvgMetricValue);
         final double expectedSumMetricValue = 2 * valueToRecord1 + 2 * valueToRecord2; // values are recorded once for each metric verification
-        verifyMetric(metricNamePrefix + "-total", description2, valueToRecord1, valueToRecord2, expectedSumMetricValue);
+        verifyMetric(metricNamePrefix + "-total", DESCRIPTION2, valueToRecord1, valueToRecord2, expectedSumMetricValue);
         assertThat(metrics.metrics().size(), equalTo(2 + 1)); // one metric is added automatically in the constructor of Metrics
     }
 
     @Test
     public void shouldAddAvgAndMinAndMaxMetricsToSensor() {
         StreamsMetricsImpl
-            .addAvgAndMinAndMaxToSensor(sensor, group, tags, metricNamePrefix, description1, description2, description3);
+            .addAvgAndMinAndMaxToSensor(sensor, group, tags, metricNamePrefix, DESCRIPTION1, DESCRIPTION2, DESCRIPTION3);
 
         final double valueToRecord1 = 18.0;
         final double valueToRecord2 = 42.0;
         final double expectedAvgMetricValue = (valueToRecord1 + valueToRecord2) / 2;
-        verifyMetric(metricNamePrefix + "-avg", description1, valueToRecord1, valueToRecord2, expectedAvgMetricValue);
-        verifyMetric(metricNamePrefix + "-min", description2, valueToRecord1, valueToRecord2, valueToRecord1);
-        verifyMetric(metricNamePrefix + "-max", description3, valueToRecord1, valueToRecord2, valueToRecord2);
+        verifyMetric(metricNamePrefix + "-avg", DESCRIPTION1, valueToRecord1, valueToRecord2, expectedAvgMetricValue);
+        verifyMetric(metricNamePrefix + "-min", DESCRIPTION2, valueToRecord1, valueToRecord2, valueToRecord1);
+        verifyMetric(metricNamePrefix + "-max", DESCRIPTION3, valueToRecord1, valueToRecord2, valueToRecord2);
         assertThat(metrics.metrics().size(), equalTo(3 + 1)); // one metric is added automatically in the constructor of Metrics
     }
 
     @Test
     public void shouldAddMinAndMaxMetricsToSensor() {
         StreamsMetricsImpl
-            .addMinAndMaxToSensor(sensor, group, tags, metricNamePrefix, description1, description2);
+            .addMinAndMaxToSensor(sensor, group, tags, metricNamePrefix, DESCRIPTION1, DESCRIPTION2);
 
         final double valueToRecord1 = 18.0;
         final double valueToRecord2 = 42.0;
-        verifyMetric(metricNamePrefix + "-min", description1, valueToRecord1, valueToRecord2, valueToRecord1);
-        verifyMetric(metricNamePrefix + "-max", description2, valueToRecord1, valueToRecord2, valueToRecord2);
+        verifyMetric(metricNamePrefix + "-min", DESCRIPTION1, valueToRecord1, valueToRecord2, valueToRecord1);
+        verifyMetric(metricNamePrefix + "-max", DESCRIPTION2, valueToRecord1, valueToRecord2, valueToRecord2);
         assertThat(metrics.metrics().size(), equalTo(2 + 1)); // one metric is added automatically in the constructor of Metrics
     }
 
     @Test
     public void shouldReturnMetricsVersionCurrent() {
         assertThat(
-            new StreamsMetricsImpl(metrics, THREAD_ID, StreamsConfig.METRICS_LATEST, time).version(),
+            new StreamsMetricsImpl(metrics, THREAD_ID1, StreamsConfig.METRICS_LATEST, time).version(),
             equalTo(Version.LATEST)
         );
     }
@@ -1021,7 +1186,7 @@ public class StreamsMetricsImplTest {
     @Test
     public void shouldReturnMetricsVersionFrom100To23() {
         assertThat(
-            new StreamsMetricsImpl(metrics, THREAD_ID, StreamsConfig.METRICS_0100_TO_24, time).version(),
+            new StreamsMetricsImpl(metrics, THREAD_ID1, StreamsConfig.METRICS_0100_TO_24, time).version(),
             equalTo(Version.FROM_0100_TO_24)
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -429,7 +429,7 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
-    public void shouldAddStoreLevelMutableMetric() {
+    public void shouldAddNewStoreLevelMutableMetric() {
         final Metrics metrics = mock(Metrics.class);
         final MetricName metricName =
             new MetricName(METRIC_NAME1, STATE_STORE_LEVEL_GROUP, DESCRIPTION1, STORE_LEVEL_TAG_MAP);
@@ -456,7 +456,7 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
-    public void shouldThrowWhenStoreLevelMutableMetricAlreadyExists() {
+    public void shouldNotAddStoreLevelMutableMetricIfAlreadyExists() {
         final Metrics metrics = mock(Metrics.class);
         final MetricName metricName =
             new MetricName(METRIC_NAME1, STATE_STORE_LEVEL_GROUP, DESCRIPTION1, STORE_LEVEL_TAG_MAP);
@@ -466,19 +466,15 @@ public class StreamsMetricsImplTest {
         replay(metrics);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
 
-        assertThrows(
-            "Store level metric " + metricName + " has already been added!",
-            IllegalStateException.class,
-            () -> streamsMetrics.addStoreLevelMutableMetric(
-                THREAD_ID1,
-                TASK_ID1,
-                SCOPE_NAME,
-                STORE_NAME1,
-                METRIC_NAME1,
-                DESCRIPTION1,
-                INFO_RECORDING_LEVEL,
-                VALUE_PROVIDER
-            )
+        streamsMetrics.addStoreLevelMutableMetric(
+            THREAD_ID1,
+            TASK_ID1,
+            SCOPE_NAME,
+            STORE_NAME1,
+            METRIC_NAME1,
+            DESCRIPTION1,
+            INFO_RECORDING_LEVEL,
+            VALUE_PROVIDER
         );
 
         verify(metrics);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -55,6 +55,7 @@ import org.rocksdb.Statistics;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -70,6 +71,7 @@ import static org.easymock.EasyMock.notNull;
 import static org.easymock.EasyMock.reset;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
@@ -547,7 +549,7 @@ public class RocksDBStoreTest {
     }
 
     @Test
-    public void shouldVerifyThatMetricsGetMeasurementsFromRocksDB() {
+    public void shouldVerifyThatMetricsRecordedFromStatisticsGetMeasurementsFromRocksDB() {
         final TaskId taskId = new TaskId(0, 0);
 
         final Metrics metrics = new Metrics(new MetricConfig().recordLevel(RecordingLevel.DEBUG));
@@ -576,6 +578,37 @@ public class RocksDBStoreTest {
             streamsMetrics.storeLevelTagMap(Thread.currentThread().getName(), taskId.toString(), METRICS_SCOPE, DB_NAME)
         ));
         assertThat((double) bytesWrittenTotal.metricValue(), greaterThan(0d));
+    }
+
+    @Test
+    public void shouldVerifyThatMetricsRecordedFromPropertiesGetMeasurementsFromRocksDB() {
+        final TaskId taskId = new TaskId(0, 0);
+
+        final Metrics metrics = new Metrics(new MetricConfig().recordLevel(RecordingLevel.INFO));
+        final StreamsMetricsImpl streamsMetrics =
+            new StreamsMetricsImpl(metrics, "test-application", StreamsConfig.METRICS_LATEST, time);
+
+        context = EasyMock.niceMock(InternalMockProcessorContext.class);
+        EasyMock.expect(context.metrics()).andStubReturn(streamsMetrics);
+        EasyMock.expect(context.taskId()).andStubReturn(taskId);
+        EasyMock.expect(context.appConfigs())
+                .andStubReturn(new StreamsConfig(StreamsTestUtils.getStreamsConfig()).originals());
+        EasyMock.expect(context.stateDir()).andStubReturn(dir);
+        EasyMock.replay(context);
+
+        rocksDBStore.init(context, rocksDBStore);
+        final byte[] key = "hello".getBytes();
+        final byte[] value = "world".getBytes();
+        rocksDBStore.put(Bytes.wrap(key), value);
+
+        final Metric numberOfEntriesActiveMemTable = metrics.metric(new MetricName(
+            "num-entries-active-mem-table",
+            StreamsMetricsImpl.STATE_STORE_LEVEL_GROUP,
+            "description is not verified",
+            streamsMetrics.storeLevelTagMap(Thread.currentThread().getName(), taskId.toString(), METRICS_SCOPE, DB_NAME)
+        ));
+        assertThat(numberOfEntriesActiveMemTable, notNullValue());
+        assertThat((BigInteger) numberOfEntriesActiveMemTable.metricValue(), greaterThan(BigInteger.valueOf(0)));
     }
 
     public static class MockRocksDbConfigSetter implements RocksDBConfigSetter {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsRecorderGaugesTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals.metrics;
+
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.junit.Test;
+import org.rocksdb.Cache;
+import org.rocksdb.RocksDB;
+import org.rocksdb.Statistics;
+
+import java.math.BigInteger;
+import java.util.Map;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.STATE_STORE_LEVEL_GROUP;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.STORE_ID_TAG;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_ID_TAG;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
+import static org.apache.kafka.streams.state.internals.metrics.RocksDBMetrics.NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.powermock.api.easymock.PowerMock.replay;
+
+public class RocksDBMetricsRecorderGaugesTest {
+    private static final String METRICS_SCOPE = "metrics-scope";
+    private static final String THREAD_ID = "thread-id";
+    private static final TaskId TASK_ID = new TaskId(0, 0);
+    private static final String STORE_NAME = "store-name";
+    private static final String SEGMENT_STORE_NAME_1 = "segment-store-name-1";
+    private static final String SEGMENT_STORE_NAME_2 = "segment-store-name-2";
+    private static final String ROCKSDB_PROPERTIES_PREFIX = "rocksdb.";
+
+    private final RocksDB dbToAdd1 = mock(RocksDB.class);
+    private final RocksDB dbToAdd2 = mock(RocksDB.class);
+    private final Cache cacheToAdd1 = mock(Cache.class);
+    private final Cache cacheToAdd2 = mock(Cache.class);
+    private final Statistics statisticsToAdd1 = mock(Statistics.class);
+    private final Statistics statisticsToAdd2 = mock(Statistics.class);
+
+    @Test
+    public void shouldGetNumberOfEntriesActiveMemTable() throws Exception {
+        final StreamsMetricsImpl streamsMetrics =
+                new StreamsMetricsImpl(new Metrics(), "test-client", StreamsConfig.METRICS_LATEST, new MockTime());
+        final RocksDBMetricsRecorder recorder = new RocksDBMetricsRecorder(METRICS_SCOPE, THREAD_ID, STORE_NAME);
+        expect(dbToAdd1.getAggregatedLongProperty(ROCKSDB_PROPERTIES_PREFIX + NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE))
+                .andStubReturn(5L);
+        expect(dbToAdd2.getAggregatedLongProperty(ROCKSDB_PROPERTIES_PREFIX + NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE))
+                .andStubReturn(3L);
+        replay(dbToAdd1, dbToAdd2);
+
+        recorder.init(streamsMetrics, TASK_ID);
+        recorder.addValueProviders(SEGMENT_STORE_NAME_1, dbToAdd1, cacheToAdd1, statisticsToAdd1);
+        recorder.addValueProviders(SEGMENT_STORE_NAME_2, dbToAdd2, cacheToAdd2, statisticsToAdd2);
+
+        final Map<MetricName, ? extends Metric> metrics = streamsMetrics.metrics();
+        final Map<String, String> tagMap = mkMap(
+            mkEntry(THREAD_ID_TAG, THREAD_ID),
+            mkEntry(TASK_ID_TAG, TASK_ID.toString()),
+            mkEntry(METRICS_SCOPE + "-" + STORE_ID_TAG, STORE_NAME)
+        );
+        final KafkaMetric metric = (KafkaMetric) metrics.get(new MetricName(
+            NUMBER_OF_ENTRIES_ACTIVE_MEMTABLE,
+            STATE_STORE_LEVEL_GROUP,
+            "description is ignored",
+            tagMap
+        ));
+
+        assertThat(metric, notNullValue());
+        assertThat(metric.metricValue(), is(BigInteger.valueOf(8)));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/RocksDBMetricsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals.metrics;
 
+import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
@@ -26,9 +27,11 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,6 +51,9 @@ public class RocksDBMetricsTest {
     private static final String TASK_ID = "test-task";
     private static final String STORE_TYPE = "test-store-type";
     private static final String STORE_NAME = "store";
+    private static final RocksDBMetricContext ROCKSDB_METRIC_CONTEXT =
+            new RocksDBMetricContext(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME);
+
     private final Metrics metrics = new Metrics();
     private final Sensor sensor = metrics.sensor("dummy");
     private final StreamsMetricsImpl streamsMetrics = createStrictMock(StreamsMetricsImpl.class);
@@ -215,6 +221,28 @@ public class RocksDBMetricsTest {
         verifySumSensor(metricNamePrefix, true, description, RocksDBMetrics::numberOfFileErrorsSensor);
     }
 
+    @Test
+    public void shouldAddNumImmutableMemTableMetric() {
+        final String name = "num-entries-active-mem-table";
+        final String description = "Current total number of entries in the active memtable";
+        final Gauge<BigInteger> valueProvider = (config, now) -> BigInteger.valueOf(10);
+        streamsMetrics.addStoreLevelMutableMetric(
+                eq(THREAD_ID),
+                eq(TASK_ID),
+                eq(STORE_TYPE),
+                eq(STORE_NAME),
+                eq(name),
+                eq(description),
+                eq(RecordingLevel.INFO),
+                eq(valueProvider)
+        );
+        replay(streamsMetrics);
+
+        RocksDBMetrics.addNumEntriesActiveMemTableMetric(streamsMetrics, ROCKSDB_METRIC_CONTEXT, valueProvider);
+
+        verify(streamsMetrics);
+    }
+
     private void verifyRateAndTotalSensor(final String metricNamePrefix,
                                           final String descriptionOfTotal,
                                           final String descriptionOfRate,
@@ -286,8 +314,7 @@ public class RocksDBMetricsTest {
         replayAll();
         replay(StreamsMetricsImpl.class);
 
-        final Sensor sensor =
-            sensorCreator.sensor(streamsMetrics, new RocksDBMetricContext(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME));
+        final Sensor sensor = sensorCreator.sensor(streamsMetrics, ROCKSDB_METRIC_CONTEXT);
 
         verifyAll();
         verify(StreamsMetricsImpl.class);


### PR DESCRIPTION
This commit adds the first RocksDB metric that exposes RocksDB property `num-entries-active-mem-table`. More specifically it introduces
- code in `StreamsMetricsImpl` that is shared by all such metrics,
- unit tests for the shared code 
- code that adds the metric
- unit tests and intergration tests for the metric

This commit only contains one metric to keep the PR at a reasonable size. All other RocksDB metrics described in KIP-607 will be added in other PRs.    

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
